### PR TITLE
use --no-renames for git status extract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 Eventum SCM hook scripts
 ========================
 
+2017-10-24, Version [3.1.3]
+----------------------------
+
+- use --no-renames for git status extract, #3
+
 2016-09-06, Version [3.1.2]
 ----------------------------
 
-- git hook does not match multiline messages. #2
+- git hook does not match multiline messages, #2
 
 2016-09-06, Version [3.1.1]
 ----------------------------

--- a/eventum-git-hook.php
+++ b/eventum-git-hook.php
@@ -129,7 +129,7 @@ function git_receive_refs()
  */
 function git_commit_files($rev)
 {
-    $file_info = execx("git show --pretty=format: --name-status $rev");
+    $file_info = execx("git show --pretty=format: --no-renames --name-status $rev");
 
     // man git-show --diff-filter
     $map = array(
@@ -144,7 +144,7 @@ function git_commit_files($rev)
         if (isset($map[$status])) {
             $change_type = $map[$status];
         } else {
-            error_log("Unknown type: $line");
+            error_log("git-show: Unknown type: $line");
             $change_type = 'unknown';
         }
 


### PR DESCRIPTION
as eventum side does not support renames, skip rename detection in git.

before:
```
$ git show --pretty=format: --name-status  15c107a752ed0d72aefb3057d287ed841173b252
R100    push.sh test.sh
```

after
```
$ git show --pretty=format: --name-status  15c107a752ed0d72aefb3057d287ed841173b252 --no-renames
D       push.sh
A       test.sh
```

see also https://github.com/eventum/eventum/pull/159#issuecomment-212006193