### PR TITLE
Use getenv() in php 7.1 to retrieve environment variables

### DIFF
--- a/helpers.php
+++ b/helpers.php
@@ -265,6 +265,10 @@ function getInput()
  */
 function get_all_env()
 {
+    if (PHP_VERSION_ID >= 70100) {
+        return getenv();
+    }
+
     ob_start();
     phpinfo(INFO_ENVIRONMENT);
     $buffer = ob_get_clean();


### PR DESCRIPTION
7.1.0	The varname can now be omitted to retrieve an associative array of all environment variables.

https://www.php.net/manual/en/function.getenv.php